### PR TITLE
Refactor ticket extraction

### DIFF
--- a/spec/EcPhp/Ecas/EcasSpec.php
+++ b/spec/EcPhp/Ecas/EcasSpec.php
@@ -18,6 +18,26 @@ require_once __DIR__ . '/CasHelper.php';
 
 class EcasSpec extends ObjectBehavior
 {
+
+    public function it_can_do_a_service_ticket_validation_with_a_request_header()
+    {
+        $from = 'http://local/';
+        $request = new ServerRequest('GET', $from, ['Authorization' => 'cas_ticket ticket']);
+
+        $this
+            ->withServerRequest($request)
+            ->requestTicketValidation(['service' => 'service'])
+            ->shouldBeAnInstanceOf(ResponseInterface::class);
+
+        $from = 'http://local/';
+        $request = new ServerRequest('GET', $from);
+
+        $this
+            ->withServerRequest($request)
+            ->requestTicketValidation(['service' => 'service'])
+            ->shouldBeNull();
+    }
+
     public function it_is_returning_xml_on_the_proxycallback()
     {
         $request = new ServerRequest('GET', 'http://local/proxycallback?pgtId=pgtId&pgtIou=pgtIou');

--- a/spec/EcPhp/Ecas/EcasSpec.php
+++ b/spec/EcPhp/Ecas/EcasSpec.php
@@ -18,7 +18,6 @@ require_once __DIR__ . '/CasHelper.php';
 
 class EcasSpec extends ObjectBehavior
 {
-
     public function it_can_do_a_service_ticket_validation_with_a_request_header()
     {
         $from = 'http://local/';

--- a/spec/EcPhp/Ecas/EcasSpec.php
+++ b/spec/EcPhp/Ecas/EcasSpec.php
@@ -35,6 +35,16 @@ class EcasSpec extends ObjectBehavior
             ->withServerRequest($request)
             ->requestTicketValidation(['service' => 'service'])
             ->shouldBeNull();
+
+        // Make sure that if a service is passed through the argument, it is
+        // not overridden.
+        $from = 'http://local/';
+        $request = new ServerRequest('GET', $from, ['Authorization' => 'cas_ticket foo']);
+
+        $this
+            ->withServerRequest($request)
+            ->requestTicketValidation(['service' => 'service', 'ticket' => 'ticket'])
+            ->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     public function it_is_returning_xml_on_the_proxycallback()
@@ -74,6 +84,35 @@ class EcasSpec extends ObjectBehavior
             ->handleProxyCallback()
             ->getStatusCode()
             ->shouldReturn(500);
+    }
+
+    public function it_support_authentication_when_a_ticket_is_in_the_request_header()
+    {
+        $from = 'http://local/';
+        $request = new ServerRequest('GET', $from, ['Authorization' => 'cas_ticket ticket']);
+
+        $this
+            ->withServerRequest($request)
+            ->supportAuthentication()
+            ->shouldReturn(true);
+
+        $from = 'http://local/';
+        $request = new ServerRequest('GET', $from);
+
+        $this
+            ->withServerRequest($request)
+            ->supportAuthentication()
+            ->shouldReturn(false);
+
+        // Make sure that if a service is passed through the argument, it is
+        // not overridden.
+        $from = 'http://local/';
+        $request = new ServerRequest('GET', $from, ['Authorization' => 'cas_ticket foo']);
+
+        $this
+            ->withServerRequest($request)
+            ->supportAuthentication(['service' => 'service', 'ticket' => 'ticket'])
+            ->shouldReturn(true);
     }
 
     public function let()

--- a/src/Ecas.php
+++ b/src/Ecas.php
@@ -127,6 +127,48 @@ final class Ecas implements CasInterface
         array $parameters = [],
         ?ResponseInterface $response = null
     ): ?ResponseInterface {
+        $ticket = $this->extractTicket();
+
+        if (null !== $ticket) {
+            $parameters += ['ticket' => $ticket];
+        }
+
+        return $this->cas->requestTicketValidation($parameters, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAuthentication(array $parameters = []): bool
+    {
+        $ticket = $this->extractTicket();
+
+        if (null !== $ticket) {
+            $parameters += ['ticket' => $ticket];
+        }
+
+        return $this->cas->supportAuthentication($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withServerRequest(ServerRequestInterface $serverRequest): CasInterface
+    {
+        $clone = clone $this;
+        $clone->serverRequest = $serverRequest;
+        $clone->cas = $clone->cas->withServerRequest($serverRequest);
+
+        return $clone;
+    }
+
+    /**
+     * Extract ticket from $request.
+     *
+     * @return string|null
+     */
+    private function extractTicket()
+    {
         // check for ticket in Authorization header as provided by OpenId
         // Authorization: cas_ticket PT-226194-QdoP...
         /** @var string $ticket */
@@ -144,30 +186,6 @@ final class Ecas implements CasInterface
             );
         }
 
-        if (null !== $ticket) {
-            $parameters += ['ticket' => $ticket];
-        }
-
-        return $this->cas->requestTicketValidation($parameters, $response);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportAuthentication(array $parameters = []): bool
-    {
-        return $this->cas->supportAuthentication($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function withServerRequest(ServerRequestInterface $serverRequest): CasInterface
-    {
-        $clone = clone $this;
-        $clone->serverRequest = $serverRequest;
-        $clone->cas = $clone->cas->withServerRequest($serverRequest);
-
-        return $clone;
+        return $ticket;
     }
 }

--- a/src/Ecas.php
+++ b/src/Ecas.php
@@ -19,14 +19,14 @@ final class Ecas implements CasInterface
     private $cas;
 
     /**
-     * @var \Psr\Http\Message\StreamFactoryInterface
-     */
-    private $streamFactory;
-
-    /**
      * @var \Psr\Http\Message\ServerRequestInterface
      */
     private $serverRequest;
+
+    /**
+     * @var \Psr\Http\Message\StreamFactoryInterface
+     */
+    private $streamFactory;
 
     public function __construct(CasInterface $cas, StreamFactoryInterface $streamFactory)
     {
@@ -56,8 +56,7 @@ final class Ecas implements CasInterface
     public function handleProxyCallback(
         array $parameters = [],
         ?ResponseInterface $response = null
-    ): ?ResponseInterface
-    {
+    ): ?ResponseInterface {
         $body = '<?xml version="1.0" encoding="utf-8"?><proxySuccess xmlns="http://www.yale.edu/tp/casClient" />';
 
         $response = $this
@@ -97,8 +96,7 @@ final class Ecas implements CasInterface
     public function requestProxyTicket(
         array $parameters = [],
         ?ResponseInterface $response = null
-    ): ?ResponseInterface
-    {
+    ): ?ResponseInterface {
         return $this->cas->requestProxyTicket($parameters, $response);
     }
 
@@ -108,8 +106,7 @@ final class Ecas implements CasInterface
     public function requestProxyValidate(
         array $parameters = [],
         ?ResponseInterface $response = null
-    ): ?ResponseInterface
-    {
+    ): ?ResponseInterface {
         return $this->cas->requestProxyValidate($parameters, $response);
     }
 
@@ -119,8 +116,7 @@ final class Ecas implements CasInterface
     public function requestServiceValidate(
         array $parameters = [],
         ?ResponseInterface $response = null
-    ): ?ResponseInterface
-    {
+    ): ?ResponseInterface {
         return $this->cas->requestServiceValidate($parameters, $response);
     }
 
@@ -130,8 +126,7 @@ final class Ecas implements CasInterface
     public function requestTicketValidation(
         array $parameters = [],
         ?ResponseInterface $response = null
-    ): ?ResponseInterface
-    {
+    ): ?ResponseInterface {
         // check for ticket in Authorization header as provided by OpenId
         // Authorization: cas_ticket PT-226194-QdoP...
         /** @var string $ticket */
@@ -149,10 +144,10 @@ final class Ecas implements CasInterface
             );
         }
 
-        if (null !== $ticket){
+        if (null !== $ticket) {
             $parameters += ['ticket' => $ticket];
         }
-        
+
         return $this->cas->requestTicketValidation($parameters, $response);
     }
 

--- a/src/Ecas.php
+++ b/src/Ecas.php
@@ -6,7 +6,6 @@ namespace EcPhp\Ecas;
 
 use EcPhp\CasLib\CasInterface;
 use EcPhp\CasLib\Configuration\PropertiesInterface;
-use EcPhp\CasLib\Utils\Uri;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -127,9 +126,7 @@ final class Ecas implements CasInterface
         array $parameters = [],
         ?ResponseInterface $response = null
     ): ?ResponseInterface {
-        $ticket = $this->extractTicket();
-
-        if (null !== $ticket) {
+        if ('' !== $ticket = $this->extractTicketFromRequestHeaders()) {
             $parameters += ['ticket' => $ticket];
         }
 
@@ -141,9 +138,7 @@ final class Ecas implements CasInterface
      */
     public function supportAuthentication(array $parameters = []): bool
     {
-        $ticket = $this->extractTicket();
-
-        if (null !== $ticket) {
+        if ('' !== $ticket = $this->extractTicketFromRequestHeaders()) {
             $parameters += ['ticket' => $ticket];
         }
 
@@ -165,27 +160,17 @@ final class Ecas implements CasInterface
     /**
      * Extract ticket from $request.
      *
-     * @return string|null
+     * @return string
      */
-    private function extractTicket()
+    private function extractTicketFromRequestHeaders(): string
     {
         // check for ticket in Authorization header as provided by OpenId
         // Authorization: cas_ticket PT-226194-QdoP...
-        /** @var string $ticket */
-        $ticket = preg_replace(
+
+        return (string) preg_replace(
             '/^cas_ticket /i',
             '',
             $this->serverRequest->getHeaderLine('Authorization') ?? ''
         );
-
-        if ('' === $ticket) {
-            $ticket = Uri::getParam(
-                $this->serverRequest->getUri(),
-                'ticket',
-                ''
-            );
-        }
-
-        return $ticket;
     }
 }


### PR DESCRIPTION
A `ticket` parameter (read from the `Authorization` headers) must be passed to the `supportAuthentication()` call, otherwise the Cas lib will miss it. 